### PR TITLE
feat: Add Data Academy project to extracurriculars

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,19 @@ to supervisory measures to mitigate material risks</p>
             <p style="clear: left;">− Managed a budget of €45k, ensuring implementation of free music instrument courses for over 100 children from disadvantaged backgrounds across 5 French cities, and increased number of volunteers by +30%</p>
             <p>− Led budgeting, financial reporting, and fundraising initiatives, saving €5k worth of equipment with donation campaigns</p>
             
-          </div>        
+          </div>
+
+          <div class="resume-item">
+            <h4><span class="left">ECB-Krisolis Data Academy Project – German Credit Default Prediction</span><span class="right" style="color: white;">Frankfurt, Germany</span> </h4>
+            <p><span style="clear: left;" class="left">Krisolis Data Academy Training Project</span><span class="right">January 2025 - June 2025</span></p>
+            <p style="clear: left;">- Built and fine-tuned a Random Forest model using GridSearchCV, achieving 78% accuracy in predicting credit default risk,
+handling data imbalances with oversampling techniques and applying IQR for outlier management.</p>
+            <p>- Conducted extensive exploratory data analysis (EDA) and feature engineering, providing insights into key drivers of credit default.</p>
+            <p>- Certificate of Data Science delivered by Krisolis and the ECB DG Statistics.</p>
+            <a href="Data%20Academy%20cohort%207%20-%20Certificate%20of%20Completion_C.%20Imperore.pdf" download>
+              <img src="images/cv.png" alt="Certificate Preview" style="width: 100px; height: auto; margin-top: 10px;">
+            </a>
+          </div>
 
     </div>
   </section><!-- End Resume Section -->


### PR DESCRIPTION
This commit adds the "ECB-Krisolis Data Academy Project" to the "Extracurricular Activities" section of the resume.

It also includes a preview image of the certificate which links to the downloadable PDF file, as requested by the user. The new entry follows the existing HTML structure and styling for consistency.