### PR TITLE
fix: Update certificate preview to use placeholder image

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@ handling data imbalances with oversampling techniques and applying IQR for outli
             <p>- Conducted extensive exploratory data analysis (EDA) and feature engineering, providing insights into key drivers of credit default.</p>
             <p>- Certificate of Data Science delivered by Krisolis and the ECB DG Statistics.</p>
             <a href="Data%20Academy%20cohort%207%20-%20Certificate%20of%20Completion_C.%20Imperore.pdf" download>
-              <img src="images/cv.png" alt="Certificate Preview" style="width: 100px; height: auto; margin-top: 10px;">
+              <img src="images/certificate_preview.png" alt="Certificate Preview" style="width: 100px; height: auto; margin-top: 10px;">
             </a>
           </div>
 


### PR DESCRIPTION
This commit updates the certificate preview in the extracurricular activities section to use a placeholder image filename (`images/certificate_preview.png`) as requested by the user.

The user will provide the actual image file later. This change replaces the previously used generic icon.